### PR TITLE
Add gino-enum-tables

### DIFF
--- a/assets/users.json
+++ b/assets/users.json
@@ -1,5 +1,9 @@
 [
   {
+    "name": "gino-enum-tables",
+    "link": "https://github.com/gazorby/gino-enum-tables"
+  },
+  {
     "name": "gino-starlette",
     "link": "https://github.com/python-gino/gino-starlette"
   },


### PR DESCRIPTION
A gino plugin for storing enum values in a table instead of a type